### PR TITLE
Depend on d2to1

### DIFF
--- a/ups/stsci_distutils.table
+++ b/ups/stsci_distutils.table
@@ -1,1 +1,3 @@
+setupRequired(python_d2to1)
+
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)


### PR DESCRIPTION
Add a missing dependency on d2to1.

Without this, pip won't detect we have `d2to1` and will attempt to automatically pull it from pypi, defeating the purpose of having `python_d2to1`.

Pulling from pypi also fails in offline environments, or environments where pulling from external repositories is administratively disabled (i.e., during `conda build`).
